### PR TITLE
Add fallbacklang argument to update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ update or download command. Run this once first before doing update and download
     -lang [LANG [LANG ...]] game language(s) (ex. en fr de)
 	-skiplang				skip game language(s)
 							Can't be used with -lang
-    -fallbacklang <LANG>    used when no language(s) from -lang is available
+    -fallbacklang [LANG [LANG ...]]    used when no language(s) from -lang is available. Only the fist existing is used.
 	-standard				update new and updated games only (default unless -ids used)
 							Can't be used with -skipknown, -updateonly, -full
     -skipknown            	only update new games in your library

--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ update or download command. Run this once first before doing update and download
     -lang [LANG [LANG ...]] game language(s) (ex. en fr de)
 	-skiplang				skip game language(s)
 							Can't be used with -lang
+    -fallbacklang <LANG>    used when no language(s) from -lang is available
 	-standard				update new and updated games only (default unless -ids used)
 							Can't be used with -skipknown, -updateonly, -full
     -skipknown            	only update new games in your library

--- a/gogrepoc.py
+++ b/gogrepoc.py
@@ -1231,7 +1231,7 @@ def fetch_file_info(d, fetch_md5,save_md5_xml,updateSession):
         else:
             d.updated = email.utils.parsedate_to_datetime(d.raw_updated).isoformat() #Standardize
 
-def filter_downloads(out_list, downloads_list, lang_list, os_list,save_md5_xml,updateSession, fallbacklang):
+def filter_downloads(out_list, downloads_list, lang_list, os_list,save_md5_xml,updateSession, fallbacklang, fallbackIdx = 0):
     """filters any downloads information against matching lang and os, translates
     them, and extends them into out_list
     """
@@ -1331,8 +1331,8 @@ def filter_downloads(out_list, downloads_list, lang_list, os_list,save_md5_xml,u
                                 #None worked so go with the canonical link
                                 error("Could not fetch file info so using canonical link: %s" % href_ds[0][0].href)
                                 filtered_downloads.append(href_ds[0][0])
-    if not len(filtered_downloads) and not fallbacklang is None:
-        filter_downloads(out_list, downloads_list, [fallbacklang], os_list,save_md5_xml,updateSession, None)
+    if not len(filtered_downloads) and not fallbacklang is None and len(fallbacklang) > fallbackIdx:
+        filter_downloads(out_list, downloads_list, [fallbacklang[fallbackIdx]], os_list,save_md5_xml,updateSession, fallbacklang, fallbackIdx + 1)
     else:
         out_list.extend(filtered_downloads)
 
@@ -1580,7 +1580,7 @@ def process_argv(argv):
     g3 = g1.add_mutually_exclusive_group()
     g3.add_argument('-lang', action=storeExtend, help='game language(s)', nargs='*', default=[])
     g3.add_argument('-skiplang', action='store', help='skip game language(s)', nargs='*', default=[])
-    g1.add_argument('-fallbacklang', action='store', help='fallback language', nargs='?', default=None)
+    g1.add_argument('-fallbacklang', action='store', help='fallback language', nargs='*', default=None)
     g1.add_argument('-skiphidden',action='store_true',help='skip games marked as hidden')
     g1.add_argument('-installers', action='store', choices = ['standalone','both'], default = 'standalone',  help='GOG Installer type to use: standalone or both galaxy and standalone. Default: standalone (Deprecated)')    
     g4 = g1.add_mutually_exclusive_group()  # below are mutually exclusive


### PR DESCRIPTION
In order to partially resolve #103 and #120, I've added a fallbacklang argument to the update command.

If set (accept only one language), it will add the specified language to the download list, if there is no downloads for the specified languages in -lang argument.

Ex. 
python3 gogrepoc.py update -os windows -lang fr -fallbacklang en
It will download all french versions and, for the games that don't have one, download the english version.

Tested on my account with more than 400 games.